### PR TITLE
Change go install instructions for modern golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It outputs a `defaults` command to recreate that change.
 
 ## Install
 ```
-go get github.com/catilac/plistwatch
+go install  github.com/catilac/plistwatch@latest
 ```
 
 ## Usage


### PR DESCRIPTION
'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version,
like 'go install example.com/cmd@latest'
For more information, see https://golang.org/doc/go-get-install-deprecation
or run 'go help get' or 'go help install'.