### PR TITLE
Restore correct order of domain-key-value

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -55,7 +55,7 @@ func Diff(d1 map[string]interface{}, d2 map[string]interface{}) error {
 						value = "'" + *s + "'"
 						break
 					}
-					fmt.Printf("defaults write \"%s\" \"%s\" %s\n", key, domain, value)
+					fmt.Printf("defaults write \"%s\" \"%s\" %s\n", domain, key, value)
 				}
 			}
 		} else {


### PR DESCRIPTION
Resolves #6.

Expected output appears to be restored:

```
% go build    
% ./plistwatch | grep com.apple.dock
defaults write "com.apple.dock" "orientation" 'left'
defaults write "com.apple.dock" "orientation" 'bottom'
^C
```