### PR TITLE
Filter by domain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ And you should see output such as:
 defaults write "com.apple.dock" "orientation" 'left'
 ```
 
+The output can also be filtered:
+```
+Usage of plistwatch:
+  -filter domains
+    	a comma-separated list of domains. Prefix names with "!" to exclude them. Supports globbing.
+```
+
+Examples:
+- Hide annoying settings domains
+`plistwatch -filter "!com.apple.knowledge-agent,!ContextStoreAgent"`
+- Only show changes to the dock
+`plistwatch -filter "com.apple.dock"`
+- Hide every Apple domain
+`plistwatch -filter "!com.apple.*"`

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/catilac/plistwatch
 
-go 1.14
+go 1.18

--- a/main.go
+++ b/main.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/catilac/plistwatch/go-plist"
@@ -19,7 +23,51 @@ func getDefaults() (bytes.Buffer, error) {
 	return out, err
 }
 
+func filterDomains(m map[string]any, include, exclude []string) {
+	maps.DeleteFunc(m, func(k string, v any) bool {
+		// Allow every domain by default
+		if len(include) == 0 {
+			return false
+		}
+		for _, pattern := range include {
+			if matched, _ := filepath.Match(pattern, k); matched {
+				return false
+			}
+		}
+		return true
+	})
+	maps.DeleteFunc(m, func(k string, v any) bool {
+		for _, pattern := range exclude {
+			if matched, _ := filepath.Match(pattern, k); matched {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func main() {
+	var include []string
+	var exclude []string
+
+	flag.Func("filter", "a comma-separated list of `domains`. Prefix names with \"!\" to exclude them. Supports globbing.", func(s string) error {
+		for _, v := range strings.Split(s, ",") {
+			domain, found := strings.CutPrefix(strings.TrimSpace(v), "!")
+			// Users might write "! com.apple.dock" so we trim again
+			domain = strings.TrimSpace(domain)
+			if domain == "" {
+				continue
+			}
+			if found {
+				exclude = append(exclude, domain)
+			} else {
+				include = append(include, domain)
+			}
+		}
+		return nil
+	})
+	flag.Parse()
+
 	var prev map[string]interface{}
 	var curr map[string]interface{}
 
@@ -29,6 +77,8 @@ func main() {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
+
+		filterDomains(curr, include, exclude)
 
 		if prev != nil {
 			if err = Diff(prev, curr); err != nil {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func filterDomains(m map[string]any, include, exclude []string) {
 			return false
 		}
 		for _, pattern := range include {
-			if matched, _ := filepath.Match(pattern, k); matched {
+			if matched, _ := filepath.Match(pattern, strings.ToLower(k)); matched {
 				return false
 			}
 		}
@@ -38,7 +38,7 @@ func filterDomains(m map[string]any, include, exclude []string) {
 	})
 	maps.DeleteFunc(m, func(k string, v any) bool {
 		for _, pattern := range exclude {
-			if matched, _ := filepath.Match(pattern, k); matched {
+			if matched, _ := filepath.Match(pattern, strings.ToLower(k)); matched {
 				return true
 			}
 		}
@@ -52,7 +52,8 @@ func main() {
 
 	flag.Func("filter", "a comma-separated list of `domains`. Prefix names with \"!\" to exclude them. Supports globbing.", func(s string) error {
 		for _, v := range strings.Split(s, ",") {
-			domain, found := strings.CutPrefix(strings.TrimSpace(v), "!")
+			v = strings.ToLower(strings.TrimSpace(v))
+			domain, found := strings.CutPrefix(v, "!")
 			// Users might write "! com.apple.dock" so we trim again
 			domain = strings.TrimSpace(domain)
 			if domain == "" {


### PR DESCRIPTION
- Fix #5

This PR enables filtering domain names by using the `-filter` flag. It supports globbing and negation. Filtering is case-insensitive to match the behaviour of the `defaults` command itself.

Examples:
- Hide annoying settings domains
`plistwatch -filter "!com.apple.knowledge-agent,!ContextStoreAgent"`
- Only show changes to the dock
`plistwatch -filter "com.apple.dock"`
- Hide every Apple domain
`plistwatch -filter "!com.apple.*"`

It adds the following usage message:
```
Usage of plistwatch:
  -filter domains
    	a comma-separated list of domains. Prefix names with "!" to exclude them. Supports globbing.
```
Go's `flag` package automatically adds `-h` and `-help` flags (but does not show them on the usage). It also does not differentiate between using `-` or `--` for flags.
I *personally* like to implement custom usage messages in my own projects to make it look a little better (basically using Python's `argparse` to generate the usage and hard-coding the output into a print statement inside `flag.Usage()` but that is just a personal preference. 
```
usage: plistwatch [-h] [--filter DOMAIN [DOMAIN ...]]

Monitor real-time changes to plist files on your system

options:
  -h, --help            show this help message and exit
  --filter DOMAIN [DOMAIN ...]
                        a comma-separated list of domains. Prefix names with "!" to exclude them. Supports globbing.
```
-------
On a side-note:
`Gopls` shows me lots of compiler warnings and hints which I would like to address in an separate PR if that's ok.
<img width="500" height="257" src="https://github.com/user-attachments/assets/4c80a7d5-12ce-42d2-b023-33a3b7b74ef3" />
